### PR TITLE
Fix overriding element classes by appending to the class list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ With [npm](https://www.npmjs.com/):
 
 ```javascript
 // last stable
-npm install mw-file-uploader@1.3.8
+npm install mw-file-uploader@1.4.0
 ```
 
 ## Usage
@@ -49,8 +49,8 @@ Available options are:
 | dropzone      | HTMLElement | `null` if `allowDrop` is `false`. If `allowDrop` is `true` and dropzone element has not been defined, FileUploader will create an empty `<div>` below the input element. | Any HTML element where files can be dragged. Only works if `allowDrop` is `true`. |
 | onAddFile     | function    | `() => {}`              | Callback function that gets passed an array of the added files |
 | onRemoveFile  | function    | `() => {}`              | Callback function that gets passed an array of the removed files |
-| fieldClass    | string      | `'file-uploader-input'` | Class(es) set to the input field. |
-| dropzoneClass | string      | `'file-uploader-dropzone'` | Class(es) set to the dropzone element. |
+| fieldClass    | string      | `'file-uploader-input'` | Class(es) added to the input field. |
+| dropzoneClass | string      | `'file-uploader-dropzone'` | Class(es) added to the dropzone element. |
 
 ### Properties
 

--- a/fileupload.js
+++ b/fileupload.js
@@ -79,7 +79,7 @@ module.exports = function (options) {
 
     // set up the field
     this.field.addEventListener('change', handleChange)
-    this.field.setAttribute('class', this.options.fieldClass)
+    this.field.classList.add(this.options.fieldClass)
     this.field.setAttribute('accept', this.options.accept)
     if (this.options.multiple) this.field.setAttribute('multiple', '')
 
@@ -105,7 +105,7 @@ module.exports = function (options) {
       })
 
       this.options.dropzone.addEventListener('drop', drop)
-      this.options.dropzone.setAttribute('class', this.options.dropzoneClass)
+      this.options.dropzone.classList.add(this.options.dropzoneClass)
     }
   }.bind(this)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mw-file-uploader",
-  "version": "1.3.8",
+  "version": "1.4.0",
   "description": "Dependency-free library for uploading files.",
   "main": "fileupload.js",
   "author": "mousewell",


### PR DESCRIPTION
Before, adding any classes to the file input would get its classes overwritten when initializing the file uploader:

```html
<input id="file" type="file" class="some classes of mine" />

-->

<input id="file" type="file" class="file-uploader-input" />
```

This PR changes the behavior so that instead of setting the whole `class` attribute, it will instead just add a new class to the class list:


```html
<input id="file" type="file" class="some classes of mine" />

-->

<input id="file" type="file" class="some classes of mine file-uploader-input" />
```

This way you can add any classes (e.g. Tailwind utilities) to the element without having to rely on any external styles and selectors.

The change is applied to both _dropzone_ and _input field_ elements.

This change sounded "big" enough so the library version is also bumped up to 1.4.0.